### PR TITLE
Improve example descriptions and add simple text example

### DIFF
--- a/examples/live_audio_in_audio_out.rs
+++ b/examples/live_audio_in_audio_out.rs
@@ -1,3 +1,6 @@
+//! Streams microphone input to Gemini and plays the model's audio responses.
+//! Expect real-time voice replies to whatever you say.
+
 use dotenv::dotenv;
 use gemini::v1beta::live::{
     Client, ClientMessage, GenerationConfig, InlineData, PartData, RealtimeInput, ResponseModality,

--- a/examples/live_audio_in_text_out.rs
+++ b/examples/live_audio_in_text_out.rs
@@ -1,3 +1,6 @@
+//! Streams microphone input to Gemini and prints text responses from the model.
+//! Expect transcribed answers in your terminal.
+
 use dotenv::dotenv;
 use gemini::v1beta::live::{
     Client, ClientMessage, GenerationConfig, InlineData, RealtimeInput, ResponseModality,

--- a/examples/live_text_in_text_out.rs
+++ b/examples/live_text_in_text_out.rs
@@ -1,0 +1,71 @@
+//! Live text in/text out example.
+//! Connects to the streaming API and echoes Gemini's text responses for your typed input.
+
+use dotenv::dotenv;
+use gemini::v1beta::live::{
+    Client, ClientContent, ClientMessage, Content, GenerationConfig, Part, PartData,
+    ResponseModality, Role, ServerMessage, Setup,
+};
+use tokio_stream::StreamExt;
+use tracing::info;
+
+#[path = "common/utils.rs"]
+mod utils;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    dotenv().ok();
+
+    if std::env::var("RUST_LOG").is_err() {
+        unsafe {
+            std::env::set_var("RUST_LOG", "debug");
+        }
+    }
+    tracing_subscriber::fmt::init();
+
+    let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
+    let model = std::env::var("GEMINI_LIVE_MODEL").expect("GEMINI_LIVE_MODEL not set");
+
+    let setup = Setup::new(format!("models/{model}"))
+        .with_system_instruction(Content::new(
+            None,
+            vec![Part::new(PartData::Text(String::from(
+                "You are a helpful assistant.",
+            )))],
+        ))
+        .with_generation_config(
+            GenerationConfig::default()
+                .with_max_output_tokens(64)
+                .with_response_modalities(vec![ResponseModality::Text]),
+        );
+
+    let (client, mut stream) = Client::connect(&api_key, setup.clone()).await?;
+
+    let _client = client.clone();
+    tokio::spawn(async move {
+        let mut stream_in = utils::stdin_stream();
+
+        while let Some(line) = stream_in.next().await {
+            if _client
+                .call(ClientMessage::ClientContent(
+                    ClientContent::new(vec![Content::new(
+                        Role::User,
+                        vec![Part::new(PartData::Text(line))],
+                    )])
+                    .is_turn_completed(true),
+                ))
+                .is_err()
+            {
+                info!("error sending message");
+                break;
+            }
+        }
+    });
+
+    while let Some(msg) = stream.next().await {
+        info!("message: {:?}", msg);
+    }
+
+    client.disconnect(None)?;
+    Ok(())
+}

--- a/examples/rest_stream_function_text_in_text_out.rs
+++ b/examples/rest_stream_function_text_in_text_out.rs
@@ -1,3 +1,6 @@
+//! Demonstrates function calling over the live streaming API.
+//! Expect streaming text replies and occasional tool calls handled in code.
+
 use dotenv::dotenv;
 use gemini::v1beta::live::{
     Client, ClientContent, ClientMessage, Content, FunctionBehavior, FunctionCall,

--- a/examples/rest_text_in_text_out.rs
+++ b/examples/rest_text_in_text_out.rs
@@ -1,3 +1,6 @@
+//! Sends a single text prompt over REST and prints the Gemini response.
+//! Expect one text reply displayed in the console.
+
 use dotenv::dotenv;
 use gemini::v1beta::{
     Content, Part, PartData, Role,


### PR DESCRIPTION
## Summary
- rename audio examples and streaming function example
- add short descriptions at the top of every example
- provide a minimal `text_in_text_out.rs` without function calls
- rename `text_in_text_out.rs` to `live_text_in_text_out.rs`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6867a91e8a64832f95d4a9b52a556cab